### PR TITLE
fix: remove done callback in start jest helper

### DIFF
--- a/src/startStrapiJest.js
+++ b/src/startStrapiJest.js
@@ -3,14 +3,13 @@ const fs = require("fs-extra");
 
 const startStrapiJest = async (callBack) => {
   /** this code is called once before any test is called */
-  beforeAll(async (done) => {
+  beforeAll(async () => {
     jest.setTimeout(50000);
     await startStrapi(callBack); // singleton so it can be called many times
-    done();
   });
 
   /** this code is called once before all the tested are finished */
-  afterAll(async (done) => {
+  afterAll(async () => {
     const dbSettings = strapi.config.get(
       "database.connections.default.settings"
     );
@@ -23,8 +22,6 @@ const startStrapiJest = async (callBack) => {
         fs.unlinkSync(tmpDbFile);
       }
     }
-
-    done();
   });
 };
 


### PR DESCRIPTION
This fix the jest error:
`Test functions cannot both take a 'done' callback and return something. Either use a 'done' callback, or return a promise.`