### PR TITLE
fix: use for loop in activatePrivileges to be async

### DIFF
--- a/src/activatePrivileges.js
+++ b/src/activatePrivileges.js
@@ -18,7 +18,6 @@ const activatePrivileges = async (
         role,
       });
     permission.enabled = 1;
-    console.log('?', permission)
     await strapiInstance
       .query("permission", "users-permissions")
       .update({ id: permission.id }, permission);

--- a/src/activatePrivileges.js
+++ b/src/activatePrivileges.js
@@ -8,8 +8,8 @@ const activatePrivileges = async (
     actions = ["count", "create", "delete", "find", "findone", "update"];
   }
 
-  actions.forEach(async (action) => {
-    permission = await strapiInstance
+  for (const action of actions) {
+    let permission = await strapiInstance
       .query("permission", "users-permissions")
       .findOne({
         type: "application",
@@ -18,11 +18,11 @@ const activatePrivileges = async (
         role,
       });
     permission.enabled = 1;
+    console.log('?', permission)
     await strapiInstance
       .query("permission", "users-permissions")
       .update({ id: permission.id }, permission);
-    return 0;
-  });
+  }
 };
 
 module.exports = { activatePrivileges };


### PR DESCRIPTION
The `actions.forEach` method will resolve instantaneously without waiting permissions to be stored.

Using `for..of` loop fix this